### PR TITLE
The repeating letter issue

### DIFF
--- a/app/src/main/java/com/rikin/cinco/domain/GameState.kt
+++ b/app/src/main/java/com/rikin/cinco/domain/GameState.kt
@@ -107,10 +107,6 @@ data class KeyboardState(
             )
         ),
     ),
-    val keyMappings: MutableMap<String, KeyState> = keyRows.map { it.keys }
-        .flatten()
-        .associateBy { it.letter }
-        .toMutableMap(),
 )
 
 data class KeyboardRowState(
@@ -132,6 +128,21 @@ sealed class GameAction {
 
 fun <T> List<T>.modify(block: MutableList<T>.() -> Unit): List<T> {
     return toMutableList().apply(block)
+}
+
+fun List<TileState>.toPriorityMap(): Map<String, LetterStatus> {
+    val statusMap = mutableMapOf<String, LetterStatus>()
+
+    this.forEach { tile: TileState ->
+        val tileLetterPriority = tile.status.priority
+        val mapLetterPriority = statusMap[tile.letter]?.priority ?: 2
+
+        if (tileLetterPriority <= mapLetterPriority) {
+            statusMap[tile.letter] = tile.status
+        }
+    }
+
+    return statusMap
 }
 
 const val ROW_SIZE = 5

--- a/app/src/main/java/com/rikin/cinco/domain/GameState.kt
+++ b/app/src/main/java/com/rikin/cinco/domain/GameState.kt
@@ -106,7 +106,11 @@ data class KeyboardState(
                 KeyState(letter = "M"),
             )
         ),
-    )
+    ),
+    val keyMappings: MutableMap<String, KeyState> = keyRows.map { it.keys }
+        .flatten()
+        .associateBy { it.letter }
+        .toMutableMap(),
 )
 
 data class KeyboardRowState(

--- a/app/src/main/java/com/rikin/cinco/domain/GameViewModel.kt
+++ b/app/src/main/java/com/rikin/cinco/domain/GameViewModel.kt
@@ -201,27 +201,31 @@ class GameViewModel(private val clipboardHelper: ClipboardHelper) : ViewModel() 
             return keyboard
         }
 
-        val updatedKeyboardState = updateKeyMappings()
-        val updatedRows = mutableListOf<KeyboardRowState>()
-        keyboard.keyRows.forEach { keyRow ->
-            val updatedKeys = mutableListOf<KeyState>()
-            keyRow.keys.forEach { key ->
-                val tileForKey = row.tiles.find { it.letter == key.letter }
+        fun updateKeyboardRows(updatedState: KeyboardState): MutableList<KeyboardRowState> {
+            val updatedRows = mutableListOf<KeyboardRowState>()
+            keyboard.keyRows.forEach { keyRow ->
+                val updatedKeys = mutableListOf<KeyState>()
+                keyRow.keys.forEach { key ->
+                    val tileForKey = row.tiles.find { it.letter == key.letter }
 
-                if (tileForKey != null && key.status.priority >= tileForKey.status.priority) {
-                    val tileLetter = updatedKeyboardState.keyMappings[tileForKey.letter]
-                        ?: throw IllegalArgumentException("Could not find the letter ${tileForKey.letter} in key mappings.")
+                    if (tileForKey != null && key.status.priority >= tileForKey.status.priority) {
+                        val tileLetter = updatedState.keyMappings[tileForKey.letter]
+                            ?: throw IllegalArgumentException("Could not find the letter ${tileForKey.letter} in key mappings.")
 
-                    updatedKeys.add(tileLetter)
-                } else {
-                    updatedKeys.add(key)
+                        updatedKeys.add(tileLetter)
+                    } else {
+                        updatedKeys.add(key)
+                    }
                 }
+                updatedRows.add(KeyboardRowState(keys = updatedKeys))
             }
-            updatedRows.add(KeyboardRowState(keys = updatedKeys))
+
+            return updatedRows
         }
-        return KeyboardState(
-            keyRows = updatedRows
-        )
+
+        val updatedKeyboardState = updateKeyMappings()
+        val updatedRows = updateKeyboardRows(updatedState = updatedKeyboardState)
+        return KeyboardState(keyRows = updatedRows)
     }
 }
 


### PR DESCRIPTION
This change fixes an issue in which the hint color (colour) of a letter could mistakenly be set to misplaced, rather than correct under certain conditions. One example of such a condition is as follows:

For example, let's assume that the correct word is "chess", and the user guessed the word "stars". The way it is currently, the letter s would be marked as misplaced because we are only looking for the first occurrence of a letter in the row of tiles. However, this change makes it so that we check all letters in the guessed word, and update their keys in the keyboard to the highest priority status, in this case correct, rather than misplaced. 